### PR TITLE
Add basic devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM rockylinux:9-minimal
+
+ENV TERM=xterm-256color
+
+RUN microdnf upgrade -y \
+  && microdnf install -y epel-release \
+  && microdnf install -y go vim \
+  && microdnf clean all -y
+

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,6 @@ ENV TERM=xterm-256color
 
 RUN microdnf upgrade -y \
   && microdnf install -y epel-release \
-  && microdnf install -y go vim \
+  && microdnf install -y git go tar vim \
   && microdnf clean all -y
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "btd-cli",
+  "build": { "dockerfile": "Dockerfile" },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "EditorConfig.EditorConfig"
+      ]
+    }
+  }
+}
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "main.go",
+            "args": [""]
+        }
+    ]
+}


### PR DESCRIPTION
These changes introduce a basic [devcontainer](https://containers.dev/) configuration for use with Visual Studio Code or [Codespaces](https://github.com/features/codespaces), in addition to a `Debug` launch configuration for debugging purposes.