### PR TITLE
Add version command

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -50,6 +50,7 @@ Examples:
 			return err
 		}
 
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
 		fmt.Println("Using tag map:", tagMap.LoadedFromFile())
 
 		path := args[0]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,6 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -75,9 +74,8 @@ func initConfig() {
 
 	viper.AutomaticEnv()
 
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	} else {
+	err := viper.ReadInConfig()
+	if err != nil {
 		switch err.(type) {
 		case viper.ConfigParseError:
 			cobra.CheckErr(err)

--- a/cmd/string.go
+++ b/cmd/string.go
@@ -49,6 +49,7 @@ Examples:
 			return err
 		}
 
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
 		fmt.Println("Using tag map:", tagMap.LoadedFromFile())
 
 		path := args[0]

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,42 @@
+/*
+Copyright © 2024 Companies House (Crown Copyright)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Long:  `Print the version number of btd-cli and exit`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("1.2.0")
+	},
+}


### PR DESCRIPTION
This change introduces a `version` command for easy identification of different versions of the CLI.