### PR TITLE
Fix table header styling

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -37,6 +37,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number",
 	Long:  `Print the version number of btd-cli and exit`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("1.2.4")
+		fmt.Println("1.2.5")
 	},
 }

--- a/pkg/btd/renderer/table/table.go
+++ b/pkg/btd/renderer/table/table.go
@@ -73,7 +73,7 @@ func (t *Table) Render(data btd.TagData) string {
 			var style lipgloss.Style
 
 			switch {
-			case row == 0:
+			case row == table.HeaderRow:
 				style = style.Inherit(HeaderStyle)
 			case row%2 == 0:
 				style = style.Inherit(EvenRowStyle)


### PR DESCRIPTION
This change fixes a table header styling issue introduced [upstream](https://github.com/charmbracelet/lipgloss/pull/377/files) whereby the header index has been changed to `-1` rather than `0`. 